### PR TITLE
Add <Plug>(qfloc-sbuffer)

### DIFF
--- a/autoload/qfloc/jump.vim
+++ b/autoload/qfloc/jump.vim
@@ -33,30 +33,4 @@ function! s:jump(init_expr, jump_expr, wrap_expr) abort
   endtry
 endfunction
 
-function! qfloc#jump#lsbuffer() abort
-  call s:sbuffer(1)
-endfunction
-
-function! qfloc#jump#csbuffer() abort
-  call s:sbuffer(0)
-endfunction
-
-function! s:sbuffer(is_loclist) abort
-  if a:is_loclist
-    let list = getloclist(winnr())
-  else
-    let list = getqflist()
-  endif
-  let item = get(list, line('.') - 1, {})
-  let bufnr = get(item, 'bufnr', -1)
-  if bufnr ==# -1
-    call qfloc#message#error('could not get buffer number')
-    return
-  endif
-  execute bufnr 'sbuffer'
-  " Go to the lnum and col
-  wincmd p
-  execute "normal! \<CR>"
-endfunction
-
 let g:qfloc#jump#wrap = get(g:, 'qfloc#jump#wrap', 1)

--- a/autoload/qfloc/jump.vim
+++ b/autoload/qfloc/jump.vim
@@ -33,4 +33,30 @@ function! s:jump(init_expr, jump_expr, wrap_expr) abort
   endtry
 endfunction
 
+function! qfloc#jump#lsbuffer() abort
+  call s:sbuffer(1)
+endfunction
+
+function! qfloc#jump#csbuffer() abort
+  call s:sbuffer(0)
+endfunction
+
+function! s:sbuffer(is_loclist) abort
+  if a:is_loclist
+    let list = getloclist(winnr())
+  else
+    let list = getqflist()
+  endif
+  let item = get(list, line('.') - 1, {})
+  let bufnr = get(item, 'bufnr', -1)
+  if bufnr ==# -1
+    call qfloc#message#error('could not get buffer number')
+    return
+  endif
+  execute bufnr 'sbuffer'
+  " Go to the lnum and col
+  wincmd p
+  execute "normal! \<CR>"
+endfunction
+
 let g:qfloc#jump#wrap = get(g:, 'qfloc#jump#wrap', 1)

--- a/autoload/qfloc/window.vim
+++ b/autoload/qfloc/window.vim
@@ -17,3 +17,29 @@ function! s:switch(open_expr, close_expr) abort
     call qfloc#message#exception()
   endtry
 endfunction
+
+function! qfloc#window#lsbuffer() abort
+  call s:sbuffer(1)
+endfunction
+
+function! qfloc#window#csbuffer() abort
+  call s:sbuffer(0)
+endfunction
+
+function! s:sbuffer(is_loclist) abort
+  if a:is_loclist
+    let list = getloclist(winnr())
+  else
+    let list = getqflist()
+  endif
+  let item = get(list, line('.') - 1, {})
+  let bufnr = get(item, 'bufnr', -1)
+  if bufnr ==# -1
+    call qfloc#message#error('could not get buffer number')
+    return
+  endif
+  execute bufnr 'sbuffer'
+  " Go to the lnum and col
+  wincmd p
+  execute "normal! \<CR>"
+endfunction

--- a/ftplugin/qf/qfloc.vim
+++ b/ftplugin/qf/qfloc.vim
@@ -7,14 +7,14 @@ let s:is_loclist = getwininfo(win_getid())[0].loclist
 if s:is_loclist
   nnoremap <silent><buffer><expr> <Plug>(qfloc-j) qfloc#motion#lmove(v:count1)
   nnoremap <silent><buffer><expr> <Plug>(qfloc-k) qfloc#motion#lmove(-v:count1)
-  nnoremap <silent><buffer> <Plug>(qfloc-sbuffer) :<C-u>call qfloc#jump#lsbuffer()<CR>
+  nnoremap <silent><buffer> <Plug>(qfloc-sbuffer) :<C-u>call qfloc#window#lsbuffer()<CR>
   nnoremap <silent><buffer> <Plug>(qfloc-undo) :<C-u>call qfloc#edit#lundo()<CR>
   nnoremap <silent><buffer> <Plug>(qfloc-delete) :call qfloc#edit#ldelete()<CR>
   vnoremap <silent><buffer> <Plug>(qfloc-delete) :call qfloc#edit#ldelete()<CR>
 else
   nnoremap <silent><buffer><expr> <Plug>(qfloc-j) qfloc#motion#cmove(v:count1)
   nnoremap <silent><buffer><expr> <Plug>(qfloc-k) qfloc#motion#cmove(-v:count1)
-  nnoremap <silent><buffer> <Plug>(qfloc-sbuffer) :<C-u>call qfloc#jump#csbuffer()<CR>
+  nnoremap <silent><buffer> <Plug>(qfloc-sbuffer) :<C-u>call qfloc#window#csbuffer()<CR>
   nnoremap <silent><buffer> <Plug>(qfloc-undo) :<C-u>call qfloc#edit#cundo()<CR>
   nnoremap <silent><buffer> <Plug>(qfloc-delete) :call qfloc#edit#cdelete()<CR>
   vnoremap <silent><buffer> <Plug>(qfloc-delete) :call qfloc#edit#cdelete()<CR>

--- a/ftplugin/qf/qfloc.vim
+++ b/ftplugin/qf/qfloc.vim
@@ -7,12 +7,14 @@ let s:is_loclist = getwininfo(win_getid())[0].loclist
 if s:is_loclist
   nnoremap <silent><buffer><expr> <Plug>(qfloc-j) qfloc#motion#lmove(v:count1)
   nnoremap <silent><buffer><expr> <Plug>(qfloc-k) qfloc#motion#lmove(-v:count1)
+  nnoremap <silent><buffer> <Plug>(qfloc-sbuffer) :<C-u>call qfloc#jump#lsbuffer()<CR>
   nnoremap <silent><buffer> <Plug>(qfloc-undo) :<C-u>call qfloc#edit#lundo()<CR>
   nnoremap <silent><buffer> <Plug>(qfloc-delete) :call qfloc#edit#ldelete()<CR>
   vnoremap <silent><buffer> <Plug>(qfloc-delete) :call qfloc#edit#ldelete()<CR>
 else
   nnoremap <silent><buffer><expr> <Plug>(qfloc-j) qfloc#motion#cmove(v:count1)
   nnoremap <silent><buffer><expr> <Plug>(qfloc-k) qfloc#motion#cmove(-v:count1)
+  nnoremap <silent><buffer> <Plug>(qfloc-sbuffer) :<C-u>call qfloc#jump#csbuffer()<CR>
   nnoremap <silent><buffer> <Plug>(qfloc-undo) :<C-u>call qfloc#edit#cundo()<CR>
   nnoremap <silent><buffer> <Plug>(qfloc-delete) :call qfloc#edit#cdelete()<CR>
   vnoremap <silent><buffer> <Plug>(qfloc-delete) :call qfloc#edit#cdelete()<CR>
@@ -22,6 +24,7 @@ nnoremap <silent><buffer> <Plug>(qfloc-preview) <CR>zz<C-w>p
 if !get(g:, 'qfloc_disable_default_mappings')
   nmap <buffer> j <Plug>(qfloc-j)
   nmap <buffer> k <Plug>(qfloc-k)
+  nmap <buffer> s <Plug>(qfloc-sbuffer)
   nmap <buffer> p <Plug>(qfloc-preview)
   nmap <buffer> u <Plug>(qfloc-undo)
   nmap <buffer> dd <Plug>(qfloc-delete)


### PR DESCRIPTION
I added this mapping because I want to do:

* Jump to the window if the buffer is opened
* Open new window if the buffer is not opened

---

Personally, I want to configure like this in my vimrc.

```vim
nmap <CR> <Plug>(qfloc-sbuffer)
set switchbuf^=useopen
```

I think the Vim default `<CR>` behavior is difficult because it opens in existing window and *I cannot predict which window is re-used.*